### PR TITLE
Handle strings that need escaping

### DIFF
--- a/index.js
+++ b/index.js
@@ -19,7 +19,16 @@ function toLua(obj) {
     }
     if (!lodash.isObject(obj)) {
         if (typeof obj === 'string') {
-            return '"' + obj + '"';
+            if (obj.includes('\n') || obj.includes('\\') || obj.includes('"')) {
+                var i = 0;
+                var end = ']]';
+                do {
+                    end = ']' + '='.repeat(i) + ']';
+                } while (obj.includes(end));
+                return '[' + '='.repeat(i) + '[' + obj + end;
+            } else {
+                return '"' + obj + '"';
+            }
         }
         return obj.toString();
     }


### PR DESCRIPTION
Instead of escaping them, just determine which kind of "quotes" are needed as Lua [supports unescaped strings wrapped in `[[...]]`](https://www.lua.org/manual/5.4/manual.html#3.1) (although docs warn the file is read in text mode which may get things wrong on binary strings).